### PR TITLE
fix: add expac specific toc files to fix out of date issue

### DIFF
--- a/TacoTip-BCC.toc
+++ b/TacoTip-BCC.toc
@@ -1,12 +1,10 @@
+## Interface: 20504
 ## Version: 0.3.4
 ## Title: TacoTip
 ## Notes: TacoTip (GearScore & Talents)
 ## Author: kebabstorm
 ## SavedVariables: TacoTipConfig
 ## OptionalDependencies: LibStub, CallbackHandler-1.0, LibDetours-1.0, LibClassicInspector, LibClassicGearScore, Pawn
-## X-Min-Interface-Classic: 11304
-## X-Min-Interface-BCC: 20504
-## X-Min-Interface-Wrath: 30400
 
 Libs\LibStub\LibStub.lua
 Libs\CallbackHandler-1.0\CallbackHandler-1.0.lua

--- a/TacoTip-Classic.toc
+++ b/TacoTip-Classic.toc
@@ -1,12 +1,10 @@
+## Interface: 11304
 ## Version: 0.3.4
 ## Title: TacoTip
 ## Notes: TacoTip (GearScore & Talents)
 ## Author: kebabstorm
 ## SavedVariables: TacoTipConfig
 ## OptionalDependencies: LibStub, CallbackHandler-1.0, LibDetours-1.0, LibClassicInspector, LibClassicGearScore, Pawn
-## X-Min-Interface-Classic: 11304
-## X-Min-Interface-BCC: 20504
-## X-Min-Interface-Wrath: 30400
 
 Libs\LibStub\LibStub.lua
 Libs\CallbackHandler-1.0\CallbackHandler-1.0.lua

--- a/TacoTip-Wrath.toc
+++ b/TacoTip-Wrath.toc
@@ -1,12 +1,10 @@
+## Interface: 30400
 ## Version: 0.3.4
 ## Title: TacoTip
 ## Notes: TacoTip (GearScore & Talents)
 ## Author: kebabstorm
 ## SavedVariables: TacoTipConfig
 ## OptionalDependencies: LibStub, CallbackHandler-1.0, LibDetours-1.0, LibClassicInspector, LibClassicGearScore, Pawn
-## X-Min-Interface-Classic: 11304
-## X-Min-Interface-BCC: 20504
-## X-Min-Interface-Wrath: 30400
 
 Libs\LibStub\LibStub.lua
 Libs\CallbackHandler-1.0\CallbackHandler-1.0.lua


### PR DESCRIPTION
As was explained in #20, it's really annoying the addon is permantently out of date. This PR is aimed to resolve this issue by implementing the specific toc files for the respective versions of classic. Please let me know if anything needs to change before this PR can be merged, happy to receive feedback.