### PR TITLE
Added spell id for new WOTLK Paladin Glyph: Glyph of Reckoning

### DIFF
--- a/Libs/LibClassicInspector/LibClassicInspector.lua
+++ b/Libs/LibClassicInspector/LibClassicInspector.lua
@@ -291,7 +291,8 @@ lib.glyphs_table = lib.glyphs_table or {
       [25] = 63222, -- Glyph of Shield of Righteousness
       [26] = 63223, -- Glyph of Divine Plea
       [27] = 63224, -- Glyph of Holy Shock
-      [28] = 63225  -- Glyph of Salvation
+      [28] = 63225, -- Glyph of Salvation
+      [29] = 405004 -- Glyph of Reckoning
     },
     [2] = {
       [1] = 57937,  -- Glyph of Blessing of Kings
@@ -2816,7 +2817,7 @@ local function addCacheUser(guid, inventory, talents, achievements, glyphs)
             else
                 local next = cache.first.next
                 cache.first = nil
-                cache.first = next 
+                cache.first = next
             end
         else
             cache.len = cache.len + 1
@@ -2936,7 +2937,7 @@ local function tryInspect(unit, refresh)
 end
 
 function f:INSPECT_READY(event, guid)
-    if (not guid) then 
+    if (not guid) then
         return
     end
     local unit = lib:PlayerGUIDToUnitToken(guid)
@@ -3144,7 +3145,7 @@ local function inspectQueueTick()
             end
         end
     end
-end 
+end
 if lib.queueTicker then
     lib.queueTicker:Cancel()
 end
@@ -3271,7 +3272,7 @@ end
 --  Returns
 --     @number status              - inspection status
 --                                   == 0 : target cannot be inspected
---                                   == 1 : instant inspection 
+--                                   == 1 : instant inspection
 --                                   == 2 : queued inspection
 --
 function lib:DoInspect(unitorguid)
@@ -3344,7 +3345,7 @@ end
 --     @string specName            - specialization name e.g. "Retribution"
 --
 function lib:GetSpecializationName(class, tabIndex, localized)
-    assert(class == "WARRIOR" or class == "PALADIN" or class == "HUNTER" or class == "ROGUE" or class == "PRIEST" or class == "SHAMAN" or 
+    assert(class == "WARRIOR" or class == "PALADIN" or class == "HUNTER" or class == "ROGUE" or class == "PRIEST" or class == "SHAMAN" or
            class == "MAGE" or class == "WARLOCK" or class == "DRUID" or (isWotlk and class == "DEATHKNIGHT"), "invalid class")
     local n = tonumber(tabIndex) or 0
     assert(n > 0 and n < 4, "tabIndex is not a valid number (1-3)")
@@ -3363,7 +3364,7 @@ end
 --     @number numTalents          - number of talents in tab
 --
 function lib:GetNumTalentsByClass(class, tabIndex)
-    assert(class == "WARRIOR" or class == "PALADIN" or class == "HUNTER" or class == "ROGUE" or class == "PRIEST" or class == "SHAMAN" or 
+    assert(class == "WARRIOR" or class == "PALADIN" or class == "HUNTER" or class == "ROGUE" or class == "PRIEST" or class == "SHAMAN" or
            class == "MAGE" or class == "WARLOCK" or class == "DRUID" or (isWotlk and class == "DEATHKNIGHT"), "invalid class")
     local n = tonumber(tabIndex) or 0
     assert(n > 0 and n < 4, "tabIndex is not a valid number (1-3)")
@@ -3582,7 +3583,7 @@ end
 --     @number talentID            - talent ID
 --
 function lib:GetTalentInfoByClass(class, tabIndex, talentIndex)
-    assert(class == "WARRIOR" or class == "PALADIN" or class == "HUNTER" or class == "ROGUE" or class == "PRIEST" or class == "SHAMAN" or 
+    assert(class == "WARRIOR" or class == "PALADIN" or class == "HUNTER" or class == "ROGUE" or class == "PRIEST" or class == "SHAMAN" or
            class == "MAGE" or class == "WARLOCK" or class == "DRUID" or (isWotlk and class == "DEATHKNIGHT"), "invalid class")
     tabIndex = tonumber(tabIndex) or 0
     assert(tabIndex > 0 and tabIndex < 4, "tabIndex is not a valid number (1-3)")
@@ -3975,7 +3976,7 @@ function lib:GetGlyphSocketInfo(unitorguid, socketID, _group)
         return nil
     end
     local n = tonumber(socketID) or 0
-    assert(n >= 1 and n <= 6, "socketID is not a valid number")    
+    assert(n >= 1 and n <= 6, "socketID is not a valid number")
     local guid = getPlayerGUID(unitorguid)
     if (not guid) then
         return nil
@@ -3991,7 +3992,7 @@ function lib:GetGlyphSocketInfo(unitorguid, socketID, _group)
     local _, class = GetPlayerInfoByGUID(guid)
     if (not class) then
         return nil
-    end    
+    end
     if (guid == UnitGUID("player")) then
         return GetGlyphSocketInfo(n, group)
     else
@@ -4046,7 +4047,7 @@ function lib:HasGlyph(unitorguid, glyphSpellID, _group)
     local _, class = GetPlayerInfoByGUID(guid)
     if (not class) then
         return nil
-    end    
+    end
     if (guid == UnitGUID("player")) then
         for i=1,6 do
             local enabled, _, id = GetGlyphSocketInfo(i, group)


### PR DESCRIPTION
There is a new bug introduced into LibClassicInspector because a new Glyph was added to WOTLK for Ret paladins:

https://www.wowhead.com/wotlk/spell=405004/glyph-of-reckoning

This bugfix, fixes the error. Simply added the proper glyph spell ID to the table.

Here is the error in question.
```
16x ...Tip/Libs/LibClassicInspector-9/LibClassicInspector.lua:3102: attempt to perform arithmetic on field '?' (a nil value)
[string "@TacoTip/Libs/LibClassicInspector-9/LibClassicInspector.lua"]:3102: in function <...Tip/Libs/LibClassicInspector/LibClassicInspector.lua:3083>
[string "@TacoTip/Libs/LibClassicInspector-9/LibClassicInspector.lua"]:3160: in function <...Tip/Libs/LibClassicInspector/LibClassicInspector.lua:3156>

Locals:
s = "01-1000000000300000000000000000042000000003000050000012023053512120023103331203123000000000000000000000000003350231103050233152312312200500003120220000000000000145D2"
(for index) = 1
(for limit) = 2
(for step) = 1
x = 1
(for index) = 6
(for limit) = 6
(for step) = 1
i = 6
z = 405004
(*temporary) = "01-1000000000300000000000000000042000000003000050000012023053512120023103331203123000000000000000000000000003350231103050233152312312200500003120220000000000000145D2"
(*temporary) = <function> defined =[C]:-1
(*temporary) = nil
(*temporary) = true
(*temporary) = true
(*temporary) = true
(*temporary) = true
(*temporary) = true
(*temporary) = nil
(*temporary) = true
(*temporary) = "nil"
(*temporary) = <function> defined @SharedXML/InterfaceUtil.lua:5
(*temporary) = "attempt to perform arithmetic on field '?' (a nil value)"
isWotlk = true
glyph_r_tbl = <table> {
 63219 = 23
 63223 = 26
 63225 = 28
 57937 = 1
 54923 = 2
 54925 = 4
 54927 = 6
 54929 = 8
 54931 = 10
 54935 = 12
 54937 = 14
 54939 = 16
 54943 = 18
 57979 = 6
 63218 = 22
 63220 = 24
 63222 = 25
 63224 = 27
 54922 = 1
 54924 = 3
 54926 = 5
 54928 = 7
 54930 = 9
 54934 = 11
 54936 = 13
 54938 = 15
 54940 = 17
 57958 = 5
 57955 = 4
 57954 = 3
 57947 = 2
 56416 = 20
 56420 = 21
 56414 = 19
}
SendAddonMessage = <function> defined =[C]:-1
C_PREFIX = "LCIV1"
```