### PR TITLE
Fix nameplate unit token lookup on TBC Anniversary (2.5.6)

### DIFF
--- a/Libs/LibClassicInspector/LibClassicInspector.lua
+++ b/Libs/LibClassicInspector/LibClassicInspector.lua
@@ -3826,8 +3826,9 @@ function lib:PlayerGUIDToUnitToken(guid)
     if (GetCVar("nameplateShowFriends") == "1" or GetCVar("nameplateShowEnemies") == "1") then
         local nameplatesArray = GetNamePlates()
         for i, nameplate in ipairs(nameplatesArray) do
-            if (UnitGUID(nameplate.namePlateUnitToken) == guid) then
-                return nameplate.namePlateUnitToken
+            local unitToken = nameplate.namePlateUnitToken or nameplate.unitToken
+            if (unitToken and UnitGUID(unitToken) == guid) then
+                return unitToken
             end
         end
     end


### PR DESCRIPTION
## Problem

After today's TBC Anniversary patch (2.5.6, build 68502), `PlayerGUIDToUnitToken` spams this error whenever nameplates are visible (441 occurrences in one session for me):

```
LibClassicInspector.lua:3829: bad argument #1 to 'UnitGUID' (Usage: local result = UnitGUID(unit))
```

The updated client renamed the nameplate frame member `namePlateUnitToken` to `unitToken`, so the loop passes `nil` into `UnitGUID()`, which now raises an error instead of silently returning nil.

Locals from the error confirm the new field name:

```
nameplate=NamePlate12 <WorldFrame.xml:21>{
 ...
 unitToken=nameplate1,
 ...
}
```

## Fix

Read `nameplate.namePlateUnitToken or nameplate.unitToken` and skip nameplates with no token, so the code keeps working on both old and new clients.